### PR TITLE
[CLBV-707] Add an announcement banner

### DIFF
--- a/app/components/announcement-banner.hbs
+++ b/app/components/announcement-banner.hbs
@@ -1,0 +1,11 @@
+{{#if this.shouldShowBanner}}
+  <AuAlert
+    @skin="warning"
+    @icon="alert-triangle"
+    @closable={{true}}
+    @size="small"
+    class="au-u-margin-bottom-none"
+  >
+    <p>{{this.message}}</p>
+  </AuAlert>
+{{/if}}

--- a/app/components/announcement-banner.js
+++ b/app/components/announcement-banner.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component';
+import config from 'frontend-verenigingen-loket/config/environment';
+
+export default class AnnouncementBanner extends Component {
+  get shouldShowBanner() {
+    return !config.announcementMessage.startsWith('{{');
+  }
+
+  get message() {
+    return config.announcementMessage;
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -14,6 +14,7 @@
   {{#if this.session.isAuthenticated}}
     <Shared::BreadCrumb />
   {{/if}}
+  <AnnouncementBanner />
   <AuMainContainer class="au-u-flex" as |m|>
     <m.content @scroll={{true}}>
       <AuBodyContainer @scroll={{true}}>

--- a/config/environment.js
+++ b/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function (environment) {
       authRedirectUrl: '{{OAUTH_API_REDIRECT_URL}}',
       switchRedirectUrl: '{{OAUTH_SWITCH_URL}}',
     },
+    announcementMessage: '{{ANNOUNCEMENT_MESSAGE}}',
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
This banner can be displayed by setting the `EMBER_ANNOUNCEMENT_MESSAGE` environment variable on the docker image.

Screenshot of what it looks like with a test message:
![image](https://github.com/user-attachments/assets/de87332e-ca51-4d27-b113-3aa9bc6202e4)

This is similar to the [OP version](https://github.com/lblod/frontend-organization-portal/pull/368), but with some changes:
- the announcement is closable. Users can close it if they've read it since it takes up screen space. This is just the built-in close, so it doesn't use cookies to "remember" the choice and a reload of the page will display it again.
- the banner is smaller. The default alert has some pretty sizeable white spaces which means it takes up more screen space than needed
- Only a single environment variable for the message which makes it simpler. If we want to have different styling options in the future we can still add that when needed.