### PR TITLE
CI setup updates

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -1,0 +1,10 @@
+steps:
+  build-feature:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ${CI_REPO}
+      tags: "feature-${CI_COMMIT_BRANCH##feature/}"
+    secrets: [ docker_username, docker_password ]
+when:
+  branch: feature/*
+  event: push

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -1,0 +1,9 @@
+steps:
+  build:
+    image: woodpeckerci/plugin-docker-buildx
+    settings:
+      repo: ${CI_REPO}
+      dry_run: true
+when:
+  event:
+    - pull_request

--- a/.woodpecker/.test-pr.yml
+++ b/.woodpecker/.test-pr.yml
@@ -1,0 +1,32 @@
+steps:
+  install:
+    image: danlynn/ember-cli:5.8.0-node_20.12
+    commands:
+      - npm ci
+  lint-js:
+    image: danlynn/ember-cli:5.8.0-node_20.12
+    group: lint
+    commands:
+      - npm run lint:js
+  lint-hbs:
+    image: danlynn/ember-cli:5.8.0-node_20.12
+    group: lint
+    commands:
+      - npm run lint:hbs
+  lint-css:
+    image: danlynn/ember-cli:5.8.0-node_20.12
+    group: lint
+    commands:
+      - npm run lint:css
+  # TODO: enable this once dependency-lint is setup
+  # dependency-lint:
+  #   image: danlynn/ember-cli:5.8.0-node_20.12
+  #   group: lint
+  #   commands:
+  #     - ember dependency-lint
+  test:
+    image: danlynn/ember-cli:5.8.0-node_20.12
+    commands:
+      - npm run test:ember
+when:
+  event: pull_request

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM madnificent/ember:5.3.0 as builder
+FROM node:20.12 AS builder
 
 LABEL maintainer="info@redpencil.io"
 
-ARG SHOW_APP_VERSION_HASH=false
-
 WORKDIR /app
-COPY package.json .
-COPY package-lock.json .
+COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
-RUN ember build -prod
+RUN npm run build
 
 FROM semtech/static-file-service:0.2.0
 COPY --from=builder /app/dist /data

--- a/app/controllers/associations.js
+++ b/app/controllers/associations.js
@@ -4,7 +4,6 @@ import { tracked } from '@glimmer/tracking';
 import { timeout, task } from 'ember-concurrency';
 import { action } from '@ember/object';
 import ENV from 'frontend-verenigingen-loket/config/environment';
-import { associationsQuery } from '../services/query-builder';
 const DEBOUNCE_MS = 500;
 
 export default class IndexController extends Controller {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "ember build --environment=production",
     "lint": "concurrently \"npm:lint:*(!fix)\" --names \"lint:\"",
-    "lint:css": "stylelint \"**/*.css\"",
+    "lint:css": "stylelint --allow-empty-input \"**/*.css\"",
     "lint:css:fix": "concurrently \"npm:lint:css -- --fix\"",
     "lint:fix": "concurrently \"npm:lint:*:fix\" --names \"fix:\"",
     "lint:hbs": "ember-template-lint .",


### PR DESCRIPTION
I noticed that we don't run the linters in CI (which is recommended) so this updates the setup a bit:

- Update to node 20 (current LTS)
- fix a linting error that snuck in
- add the missing pipelines from the [ci-templates repo ](https://github.com/redpencilio/ci-templates/tree/f364ef170a4f4564cda39fd2ae11ec8f984c06ef/woodpecker/ember/app) which also includes the pipeline that runs the linters