### PR TITLE
[CLBV-831] Reorder the fields on the recognition creation page

### DIFF
--- a/app/components/data-card.hbs
+++ b/app/components/data-card.hbs
@@ -13,9 +13,6 @@
     <div class="au-c-card__content">
       {{yield
         (hash
-          Grid=(component
-            "card-grid" itemComponent=(component "data-card/item" isGrid=true)
-          )
           Columns=(component
             "card-columns" itemComponent=(component "data-card/item")
           )

--- a/app/components/recognition/form.hbs
+++ b/app/components/recognition/form.hbs
@@ -31,6 +31,24 @@
                   </div>
                 </:content>
               </Item>
+            </:left>
+            <:right as |Item|>
+              <Item>
+                <:label>
+                  <AuLabel />
+                </:label>
+                <:content>
+                  <AuInput class="visibility-hidden" />
+                  <AuHelpText
+                    class="visibility-hidden"
+                    @error={{this.validationErrors.dateDocument}}
+                  >{{this.validationErrors.dateDocument}}</AuHelpText>
+                </:content>
+              </Item>
+            </:right>
+          </Card.Columns>
+          <Card.Columns>
+            <:left as |Item|>
               <Item>
                 <:label>
                   <AuLabel
@@ -50,6 +68,31 @@
                   >{{this.validationErrors.startTime}}</AuHelpText>
                 </:content>
               </Item>
+            </:left>
+            <:right as |Item|>
+              <Item>
+                <:label>
+                  <AuLabel
+                    @inline={{true}}
+                    @required={{true}}
+                  >Einddatum</AuLabel></:label>
+                <:content>
+                  <Datepicker
+                    class="au-u-1-1"
+                    @error={{this.validationErrors.endTime}}
+                    @value={{this.getEndDate}}
+                    @onChange={{fn (mut model.endTime)}}
+                    {{on "input" (fn this.clearFormError "endTime")}}
+                  />
+                  <AuHelpText
+                    @error={{this.validationErrors.endTime}}
+                  >{{this.validationErrors.endTime}}</AuHelpText>
+                </:content>
+              </Item>
+            </:right>
+          </Card.Columns>
+          <Card.Columns>
+            <:left as |Item|>
               <Item>
                 <:label>
                   <AuLabel @inline={{true}} @required={{true}}>Erkend door</AuLabel></:label>
@@ -96,38 +139,6 @@
               </Item>
             </:left>
             <:right as |Item|>
-              <Item>
-                <:label>
-                  <AuLabel />
-                </:label>
-                <:content>
-                  <AuInput class="visibility-hidden" />
-                  <AuHelpText
-                    class="visibility-hidden"
-                    @error={{this.validationErrors.dateDocument}}
-                  >{{this.validationErrors.dateDocument}}</AuHelpText>
-                </:content>
-              </Item>
-
-              <Item>
-                <:label>
-                  <AuLabel
-                    @inline={{true}}
-                    @required={{true}}
-                  >Einddatum</AuLabel></:label>
-                <:content>
-                  <Datepicker
-                    class="au-u-1-1"
-                    @error={{this.validationErrors.endTime}}
-                    @value={{this.getEndDate}}
-                    @onChange={{fn (mut model.endTime)}}
-                    {{on "input" (fn this.clearFormError "endTime")}}
-                  />
-                  <AuHelpText
-                    @error={{this.validationErrors.endTime}}
-                  >{{this.validationErrors.endTime}}</AuHelpText>
-                </:content>
-              </Item>
               {{#if
                 (eq
                   (get this "currentRecognition.selectedItem")

--- a/app/components/recognition/form.hbs
+++ b/app/components/recognition/form.hbs
@@ -15,7 +15,11 @@
             <:left as |Item|>
               <Item>
                 <:label>
-                  <AuLabel @inline={{true}} @required={{true}}>Erkend op</AuLabel></:label>
+                  <AuLabel
+                    @inline={{true}}
+                    @required={{true}}
+                    for="recognized-on"
+                  >Erkend op</AuLabel></:label>
                 <:content>
                   <div class="au-u-1-1">
                     <Datepicker
@@ -23,6 +27,7 @@
                       @value={{convert-to-date model.dateDocument}}
                       @error={{this.validationErrors.dateDocument}}
                       @onChange={{fn (mut model.dateDocument)}}
+                      id="recognized-on"
                       {{on "input" (fn this.clearFormError "dateDocument")}}
                     />
                     <AuHelpText
@@ -54,6 +59,7 @@
                   <AuLabel
                     @inline={{true}}
                     @required={{true}}
+                    for="start-time"
                   >Ingangsdatum</AuLabel></:label>
                 <:content>
                   <Datepicker
@@ -62,6 +68,7 @@
                     @onChange={{fn (mut model.startTime)}}
                     {{on "input" (fn this.clearFormError "startTime")}}
                     @error={{this.validationErrors.startTime}}
+                    id="start-time"
                   />
                   <AuHelpText
                     @error={{this.validationErrors.startTime}}
@@ -75,6 +82,7 @@
                   <AuLabel
                     @inline={{true}}
                     @required={{true}}
+                    for="end-time"
                   >Einddatum</AuLabel></:label>
                 <:content>
                   <Datepicker
@@ -82,6 +90,7 @@
                     @error={{this.validationErrors.endTime}}
                     @value={{this.getEndDate}}
                     @onChange={{fn (mut model.endTime)}}
+                    id="end-time"
                     {{on "input" (fn this.clearFormError "endTime")}}
                   />
                   <AuHelpText
@@ -95,12 +104,13 @@
             <:left as |Item|>
               <Item>
                 <:label>
-                  <AuLabel @inline={{true}} @required={{true}}>Erkend door</AuLabel></:label>
+                  <AuLabel @inline={{true}} @required={{true}} for="awarded-by">Erkend door</AuLabel></:label>
                 <:content>
                   <PowerSelect
                     @options={{this.items}}
                     @selected={{this.currentRecognition.selectedItem}}
                     @onChange={{fn (mut this.currentRecognition.selectedItem)}}
+                    @triggerId="awarded-by"
                     as |name|
                   >
                     {{name}}
@@ -118,13 +128,14 @@
                         <AuLabel
                           @inline={{true}}
                           @required={{true}}
+                          for="awarded-by-organization-name"
                         >Namelijk</AuLabel></div>
                       <div class="au-u-flex au-u-flex--column au-u-1-1">
                         <AuInput
                           placeholder="Vul in organisatie"
                           @value={{mut model.awardedBy}}
                           {{on "input" (fn this.clearFormError "awardedBy")}}
-                          id="awardedBy"
+                          id="awarded-by-organization-name"
                           @error={{this.validationErrors.awardedBy}}
                           @width={{"block"}}
                         />
@@ -147,7 +158,7 @@
               }}
                 <Item>
                   <:label>
-                    <AuLabel @inline={{true}}>Erkenningsbesluit</AuLabel>
+                    <AuLabel @inline={{true}} for="legal-resource">Erkenningsbesluit</AuLabel>
                   </:label>
                   <:content>
                     <AuInput
@@ -155,7 +166,7 @@
                       @value={{mut model.legalResource}}
                       {{on "input" (fn this.clearFormError "legalResource")}}
                       @width={{"block"}}
-                      id="erkenningsbesluit"
+                      id="legal-resource"
                       @error={{this.validationErrors.legalResource}}
                     />
                     <AuHelpText


### PR DESCRIPTION
This makes the tab order more intuitive.

[Screencast from 2024-07-17 16-51-22.webm](https://github.com/user-attachments/assets/f1aa2b92-b48c-4b21-804c-7de798b864ef)


I've also linked the labels to the input fields, which improves accessibility and UX.