### PR TITLE
Some improvements to deal with "upcoming" recognitions

### DIFF
--- a/app/components/recognition/general-card.hbs
+++ b/app/components/recognition/general-card.hbs
@@ -92,7 +92,7 @@
               {{/if}}
             </:right>
           </Card.Columns>
-        {{else}}
+        {{else if (is-period-expired @recognition.validityPeriod)}}
           <Card.Columns>
             <:left as |Item|>
               <Item>
@@ -111,6 +111,16 @@
               </Item>
             </:right>
           </Card.Columns>
+        {{else}}
+          <div class="au-u-flex au-u-flex--center">
+            <p><span
+                class="au-c-help-text--tertiary au-u-padding-right-tiny"
+              >Deze vereniging heeft geen actieve erkenning.</span>
+              <AuLink @skin="link" @route="association.recognition.create">
+                Voeg de erkenning toe.
+              </AuLink>
+            </p>
+          </div>
         {{/if}}
       {{else}}
         <div class="au-u-flex au-u-flex--center">

--- a/app/components/recognition/overview-card.hbs
+++ b/app/components/recognition/overview-card.hbs
@@ -17,7 +17,7 @@
               )
             }}
               <AuPill @skin="success">Erkend</AuPill>
-            {{else}}
+            {{else if (is-period-expired @recognition.validityPeriod)}}
               <AuPill @skin="warning">Verlopen</AuPill>
             {{/if}}
           </:content>

--- a/app/components/recognition/status.js
+++ b/app/components/recognition/status.js
@@ -29,7 +29,11 @@ export default class StatusComponent extends Component {
         } else if (today >= new Date(startTime) && today <= new Date(endTime)) {
           active = 'Erkend';
           resolve(active);
-        } else if (active === null && index == recognitions.length - 1) {
+        } else if (
+          active === null &&
+          index == recognitions.length - 1 &&
+          new Date(endTime) < today
+        ) {
           active = 'Verlopen';
           resolve(active);
         }

--- a/app/helpers/is-period-expired.js
+++ b/app/helpers/is-period-expired.js
@@ -1,0 +1,3 @@
+export default function isPeriodExpired(period) {
+  return Boolean(period?.endTime) && new Date(period.endTime) < new Date();
+}

--- a/app/helpers/is-period-upcoming.js
+++ b/app/helpers/is-period-upcoming.js
@@ -1,0 +1,3 @@
+export default function isPeriodUpcoming(period) {
+  return Boolean(period?.startTime) && new Date(period.startTime) > new Date();
+}

--- a/app/models/recognition.js
+++ b/app/models/recognition.js
@@ -11,7 +11,7 @@ export default class RecognitionModel extends Model {
   association;
   @belongsTo('period', {
     inverse: null,
-    async: true,
+    async: false,
   })
   validityPeriod;
   @belongsTo('administrative-unit', {

--- a/app/services/query-builder.js
+++ b/app/services/query-builder.js
@@ -70,15 +70,24 @@ export const associationsQuery = ({ index, page, params, size }) => {
     if (params.status === 'Erkend') {
       addFilter(
         ':query:recognitions.validityPeriod',
-        `((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today}))`,
+        `((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today})) OR (NOT (recognitions.validityPeriod.startTime:>${today}) AND (recognitions.validityPeriod.endTime:>${today}))`,
       );
       addFilter(':has:recognitions.validityPeriod.endTime', true);
     } else if (params.status === 'Verlopen') {
       addFilter(
         ':query:recognitions.validityPeriod',
-        `(NOT ((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today}))) AND (recognitions.validityPeriod.endTime:<${today})`,
+        `(NOT ((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today}))) AND NOT (recognitions.validityPeriod.startTime:>${today})`,
       );
       addFilter(':has:recognitions.validityPeriod.endTime', true);
+    } else if (
+      params.status === 'Erkend,Verlopen' ||
+      params.status === 'Verlopen,Erkend'
+    ) {
+      // Filter out "upcoming" recognitions when both filters are selected
+      addFilter(
+        ':query:recognitions.validityPeriod',
+        `((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today})) OR ((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:<=${today}))`,
+      );
     }
     return filters;
   };

--- a/app/services/query-builder.js
+++ b/app/services/query-builder.js
@@ -76,7 +76,7 @@ export const associationsQuery = ({ index, page, params, size }) => {
     } else if (params.status === 'Verlopen') {
       addFilter(
         ':query:recognitions.validityPeriod',
-        `(NOT ((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today})))`,
+        `(NOT ((recognitions.validityPeriod.startTime:<=${today}) AND (recognitions.validityPeriod.endTime:>=${today}))) AND (recognitions.validityPeriod.endTime:<${today})`,
       );
       addFilter(':has:recognitions.validityPeriod.endTime', true);
     }


### PR DESCRIPTION
Some of the UI elements assumed that a recognition was expired if it was not currently active, but it is also possible that it hasn't been started yet. This adds some extra conditions so the "expired" label is only displayed when needed.