### PR TITLE
Add joi validation for pdf files only

### DIFF
--- a/app/components/recognition/form.js
+++ b/app/components/recognition/form.js
@@ -131,13 +131,15 @@ export default class FormComponent extends Component {
       startTime,
       endTime,
     );
+    const isNew = !this.legalResourceFile?.id && this.legalResourceFile?.isNew;
+
     const err = errorValidation.validate({
       ...this.currentRecognition.recognitionModel,
       awardedBy:
         this.items[0] === this.currentRecognition.selectedItem
           ? this.currentRecognition.selectedItem
           : this.currentRecognition.recognitionModel.awardedBy,
-      file: await this.legalResourceFile,
+      file: isNew ? await this.legalResourceFile : null,
     });
     this.validationErrors = err.error
       ? this.mapValidationDetailsToErrors(err.error.details)

--- a/app/validations/recognition-validation.js
+++ b/app/validations/recognition-validation.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-const websiteRegex = /^https:\/\//;
+const websiteRegex = /^https:\/\/.+/;
 export const errorValidation = Joi.object()
   .keys({
     dateDocument: Joi.date()
@@ -33,6 +33,16 @@ export const errorValidation = Joi.object()
       'string.base':
         'Gelieve de entiteit in te vullen die de erkenning toekent.',
     }),
-    file: Joi.any().messages({}),
+    file: Joi.object()
+      .allow(null)
+      .custom((value, helpers) => {
+        if (!(value instanceof File)) {
+          return helpers.message('Gelieve een bestand te kiezen.');
+        }
+        if (!value.name.endsWith('.pdf')) {
+          return helpers.message('Enkel een PDF-bestand is toegelaten.');
+        }
+        return value;
+      }),
   })
   .options({ abortEarly: false });

--- a/app/validations/recognition-validation.js
+++ b/app/validations/recognition-validation.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-const websiteRegex = /^https:\/\/.+/;
+const websiteRegex = /^https:\/\//;
 export const errorValidation = Joi.object()
   .keys({
     dateDocument: Joi.date()


### PR DESCRIPTION
CLBV-924 Able to add non-PDF files to recognition
Issue
Currently the user isn’t prevented by a validation message when uploading a different file type from PDF.

Expected
When user adds any other file than a PDF-file > platform shows error message ‘Enkel een PDF-bestand is toegelaten.’