### PR TITLE
do not show duplicate associations in overview

### DIFF
--- a/app/services/mu-search.js
+++ b/app/services/mu-search.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 export default class MuSearchService extends Service {
   async search(request) {
-    const { index, page, size, sort, filters } = request;
+    const { index, page, size, sort, filters, collapseUuids } = request;
     try {
       const params = [];
       if (size) {
@@ -15,6 +15,10 @@ export default class MuSearchService extends Service {
         Object.entries(filters).forEach(([field, q]) => {
           params.push(`filter[${field}]=${q}`);
         });
+      }
+
+      if (collapseUuids) {
+        params.push(`collapse_uuids=${collapseUuids}`);
       }
 
       if (sort) {

--- a/app/services/query-builder.js
+++ b/app/services/query-builder.js
@@ -24,7 +24,13 @@ export default class QueryBuilderService extends Service {
   });
 }
 
-export const associationsQuery = ({ index, page, params, size }) => {
+export const associationsQuery = ({
+  index,
+  page,
+  params,
+  size,
+  distinct = true,
+}) => {
   const request = {};
   const search = params.search;
   request.index = index;
@@ -162,6 +168,10 @@ export const associationsQuery = ({ index, page, params, size }) => {
   request.page = page;
   request.size = size;
   request.sort = params.sort || '-createdOn';
+
+  if (distinct) {
+    request.collapseUuids = 't';
+  }
 
   request.filters = filters;
   return request;


### PR DESCRIPTION
Avoid showing duplicate associations in the overview when the user has access to multiple ES indexes.
cf https://github.com/mu-semtech/mu-search?tab=readme-ov-file#removing-duplicate-results