### PR TITLE
[CLBV-957] Load the activity and type filter data differently

### DIFF
--- a/app/components/filters/activity-select.js
+++ b/app/components/filters/activity-select.js
@@ -30,14 +30,11 @@ export default class ActivityMultipleSelectComponent extends Component {
   }
 
   loadActivities = task({ drop: true }, async () => {
-    const conceptScheme = await this.store.findRecord(
-      'concept-scheme',
-      // id of concept scheme representing the types.
-      '6c10d98a-9089-4fe8-ba81-3ed136db0265',
-    );
-    this.activities = await conceptScheme.topConcept;
-    this.activities = await [...this.activities].sort(function (a, b) {
-      return a.prefLabel.localeCompare(b.prefLabel);
+    const ACTIVITIES_CONCEPT_SCHEME = '6c10d98a-9089-4fe8-ba81-3ed136db0265';
+    this.activities = await this.store.query('concept', {
+      'filter[top-concept-of][:id:]': ACTIVITIES_CONCEPT_SCHEME,
+      sort: 'pref-label',
+      'page[size]': 1000, // TODO: This is a temporary workaround, remove this once we have a better UI solution
     });
     this.args.onChange(this.selectedActivities());
   });

--- a/app/components/filters/type-select.js
+++ b/app/components/filters/type-select.js
@@ -38,13 +38,12 @@ export default class ActivityMultipleSelectComponent extends Component {
   }
 
   loadTypes = task({ drop: true }, async () => {
-    const conceptScheme = await this.store.findRecord(
-      'concept-scheme',
-      // id of concept scheme representing the types.
-      'f3c67343-57f8-587e-89a8-afe88ccsc8',
-    );
+    const TYPES_CONCEPT_SCHEME = 'f3c67343-57f8-587e-89a8-afe88ccsc8';
+    this.types = await this.store.query('concept', {
+      'filter[top-concept-of][:id:]': TYPES_CONCEPT_SCHEME,
+      'page[size]': 1000, // TODO: This is a temporary workaround, remove this once we have a better UI solution
+    });
 
-    this.types = await conceptScheme.topConcept;
     this.args.onChange(this.selectedTypes());
   });
 }


### PR DESCRIPTION
The previous implementation used the relationship data which is paginated by mu-cl-resources and results in only the first 20 results being returned.

We now use a query with a large page size as a way to load all the data. This should be fine since we don't expect huge amounts of data, but most likely still more than 20.

This change fixes a similar issue as #70 but with a simpler solution since there aren't as many potential values.

On QA this fixes an issue already since the activity filter should display 21 items, but it only showed 20 ("Kunsten, Erfgoed & Cultuur" was missing).