### PR TITLE
[CLBV-965] Fix an issue with file downloads in Firefox

### DIFF
--- a/app/components/recognition/form.js
+++ b/app/components/recognition/form.js
@@ -392,7 +392,10 @@ export default class FormComponent extends Component {
         document.body.appendChild(a);
         a.click();
         a.remove();
-        window.URL.revokeObjectURL(url);
+
+        setTimeout(() => {
+          window.URL.revokeObjectURL(url);
+        }, 1);
       }
     } catch (error) {
       console.error('An error occurred while opening the file', error);

--- a/app/services/file.js
+++ b/app/services/file.js
@@ -22,7 +22,11 @@ export default class FileService extends Service {
         document.body.appendChild(a);
         a.click();
         a.remove();
-        window.URL.revokeObjectURL(url);
+
+        setTimeout(() => {
+          window.URL.revokeObjectURL(url);
+        }, 1);
+
         return true;
       } catch (error) {
         console.error(error.message);


### PR DESCRIPTION
It seems Firefox is sensitive to when `revokeObjectURL` is called. When called too "early"  it will throw a `Uncaught Error: Access to 'blob:http://localhost:4200/3f5f6ff8-a1f8-4636-9f34-977f5f76adbd' from script denied` error instead of opening the file.

When delaying the `revokeObjectURL` call, everything works as expected.

More information: https://stackoverflow.com/a/30708820