### PR TITLE
[CLBV-970] Fix an issue with file downloads in Chrome

### DIFF
--- a/app/components/recognition/form.js
+++ b/app/components/recognition/form.js
@@ -385,6 +385,12 @@ export default class FormComponent extends Component {
       if (file.id) {
         await this.file.getFile(file);
       } else {
+        // We intentionally don't call URL.revokeObjectURL because it breaks file downloads in Chrome.
+        // The revoked url causes the download to fail, even if the file is still visible in the browser's built-in pdf viewer.
+        // We could go for a long delay before calling revokeObjectURL,
+        // but that could still fail if the user keeps a file open for a very long time before downloading.
+        // The browser does clean up these references when all the tabs of the app are closed,
+        // so not calling revokeObjectURL simply means the data stays in memory longer.
         const url = window.URL.createObjectURL(file.download);
         const a = document.createElement('a');
         a.href = url;
@@ -392,10 +398,6 @@ export default class FormComponent extends Component {
         document.body.appendChild(a);
         a.click();
         a.remove();
-
-        setTimeout(() => {
-          window.URL.revokeObjectURL(url);
-        }, 1);
       }
     } catch (error) {
       console.error('An error occurred while opening the file', error);

--- a/app/services/file.js
+++ b/app/services/file.js
@@ -15,6 +15,12 @@ export default class FileService extends Service {
           );
         }
         const fileBlob = await response.blob();
+        // We intentionally don't call URL.revokeObjectURL because it breaks file downloads in Chrome.
+        // The revoked url causes the download to fail, even if the file is still visible in the browser's built-in pdf viewer.
+        // We could go for a long delay before calling revokeObjectURL,
+        // but that could still fail if the user keeps a file open for a very long time before downloading.
+        // The browser does clean up these references when all the tabs of the app are closed,
+        // so not calling revokeObjectURL simply means the data stays in memory longer.
         const url = window.URL.createObjectURL(fileBlob);
         const a = document.createElement('a');
         a.href = url;
@@ -22,10 +28,6 @@ export default class FileService extends Service {
         document.body.appendChild(a);
         a.click();
         a.remove();
-
-        setTimeout(() => {
-          window.URL.revokeObjectURL(url);
-        }, 1);
 
         return true;
       } catch (error) {


### PR DESCRIPTION
It seems that calling `revokeObjectURL` breaks the ability to download a file from the built-in PDF viewer. The url is released, so it can't be downloaded anymore. Firefox doesn't have this issue. There is no way for us to know when the user downloaded the file, so we can't delay the `revokeObjectURL` call until that happens.

Instead of choosing a very long (hour+) delay, we just don't call `revokeObjectURL` and let the browser handle it when the tabs are closed. This is more correct, at the cost of keeping the files in memory until the browser cleans it up.