### PR TITLE
[CLBV-1077] Display an error message when something goes wrong during the save

### DIFF
--- a/app/templates/association/representatives/edit.gjs
+++ b/app/templates/association/representatives/edit.gjs
@@ -27,6 +27,7 @@ import { removeItem } from 'frontend-verenigingen-loket/utils/array';
 import {
   createOrUpdateRepresentative,
   removeRepresentative,
+  handleError,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister';
 import { validateRecord } from 'frontend-verenigingen-loket/validations/validate-record';
 import {
@@ -37,6 +38,7 @@ import {
 export default class RepresentativesEdit extends Component {
   @service router;
   @service store;
+  @service toaster;
   representativesToRemove = [];
 
   get isLoading() {
@@ -145,19 +147,23 @@ export default class RepresentativesEdit extends Component {
     );
 
     if (isValid) {
-      const sortedRepresentatives = [
-        ...this.representatives.filter((rep) => !rep.isPrimary),
-        ...this.representatives.filter((rep) => rep.isPrimary),
-      ];
-      for (const representative of sortedRepresentatives) {
-        await createOrUpdateRepresentative(representative, this.association);
-      }
+      try {
+        const sortedRepresentatives = [
+          ...this.representatives.filter((rep) => !rep.isPrimary),
+          ...this.representatives.filter((rep) => rep.isPrimary),
+        ];
+        for (const representative of sortedRepresentatives) {
+          await createOrUpdateRepresentative(representative, this.association);
+        }
 
-      for (const representative of this.representativesToRemove) {
-        await removeRepresentative(representative, this.association);
-      }
+        for (const representative of this.representativesToRemove) {
+          await removeRepresentative(representative, this.association);
+        }
 
-      this.router.transitionTo('association.representatives');
+        this.router.transitionTo('association.representatives');
+      } catch (error) {
+        handleError(this.toaster, error);
+      }
     }
   });
 

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -308,3 +308,13 @@ type AttributeMap<T> = {
     | string
     | ((value: unknown, mapped: Record<string, unknown>) => void);
 };
+
+export function handleError(
+  toaster: { error: (message: string, title?: string) => void },
+  error: Error,
+) {
+  toaster.error(
+    'Er ging iets fout bij het verzenden van de gegevens naar het Verenigingsregister.',
+  );
+  console.error(error, JSON.stringify(error));
+}


### PR DESCRIPTION
Builds on #101 and #103 so draft until those are merged.

A bit hard to test without manually throwing errors in the code, or disabling the network before sending the requests, but _any_ exception should now display a generic error message so users know something went wrong.

<img width="421" height="236" alt="image" src="https://github.com/user-attachments/assets/737d04c1-a28d-438f-8ed0-907522c99d99" />
