### PR TITLE
[DL-6934] Fix a race condition when persisting contact changes

### DIFF
--- a/app/templates/association/contact-details/edit.gjs
+++ b/app/templates/association/contact-details/edit.gjs
@@ -113,20 +113,18 @@ export default class ContactEdit extends Component {
     }
 
     try {
-      await Promise.all(
-        this.contactPointsToRemove.map((contactPoint) => {
-          return removeContactDetail(contactPoint);
-        }),
-      );
+      for (const contactPoint of this.contactPointsToRemove) {
+        await removeContactDetail(contactPoint);
+      }
       this.contactPointsToRemove = [];
 
-      const savePromises = this.contactPoints
-        .filter((contactPoint) => contactPoint.hasDirtyAttributes)
-        .map((contactPoint) => {
-          return createOrUpdateContactDetail(contactPoint);
-        });
+      const contactPointsToSave = this.contactPoints.filter(
+        (contactPoint) => contactPoint.hasDirtyAttributes,
+      );
 
-      await Promise.all(savePromises);
+      for (const contactPoint of contactPointsToSave) {
+        await createOrUpdateContactDetail(contactPoint);
+      }
 
       const association = this.association;
       const site = this.correspondenceAddressSite;


### PR DESCRIPTION
The Verenigingsregister API doesn't support running write actions in parallel and will sometimes return a 412 response with the following message: `De gevraagde vereniging heeft niet de verwachte sequentiewaarde.`

By running the requests in sequence we fix the problem at the cost of having a slightly slower experience.

https://vlaamseoverheid.atlassian.net/wiki/spaces/MG/pages/6564610476/Veel+gestelde+vragen+Verenigingsregister#expectedSequence-en-ETag

Builds on #104