### PR TITLE
[CLBV-1206] Add support for white space in phone numbers

### DIFF
--- a/app/components/phone-input.gts
+++ b/app/components/phone-input.gts
@@ -29,7 +29,7 @@ interface PhoneInputSignature {
 
 export default class PhoneInput extends Component<PhoneInputSignature> {
   get warningMessage() {
-    const phone = this.args.value;
+    const phone = this.args.value?.trim().replaceAll(' ', '');
 
     if (!phone) {
       return undefined;

--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -61,6 +61,7 @@ import {
   isEmptyAdres,
   isPostcodeInFlanders,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister/adres';
+import { phoneRegex } from 'frontend-verenigingen-loket/utils/validations/phone';
 
 interface ContactEditSignature {
   Args: {
@@ -815,13 +816,10 @@ export const contactgegevenValidationSchema = Joi.object({
         },
         {
           is: 'Telefoon' satisfies ContactgegevenType,
-          then: Joi.string()
-            .required()
-            .regex(/^(tel:)?\+?[0-9]*$/)
-            .messages({
-              'string.pattern.base':
-                'Enkel een plusteken en cijfers zijn toegelaten.',
-            }),
+          then: Joi.string().required().regex(phoneRegex).messages({
+            'string.pattern.base':
+              'Enkel een plusteken en cijfers zijn toegelaten.',
+          }),
         },
         {
           is: 'Website' satisfies ContactgegevenType,

--- a/app/utils/validations/phone.ts
+++ b/app/utils/validations/phone.ts
@@ -1,0 +1,1 @@
+export const phoneRegex = /^(tel:)?\+?[0-9](?: ?[0-9])*$/;

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -7,6 +7,7 @@ import type Concept from 'frontend-verenigingen-loket/models/concept';
 import { isValidRijksregisternummer } from 'frontend-verenigingen-loket/utils/rijksregisternummer';
 import type TrackedData from 'frontend-verenigingen-loket/utils/tracked-data';
 import Joi from 'joi';
+import { phoneRegex } from './validations/phone';
 
 const manager = new RequestManager().use([Fetch]);
 
@@ -576,13 +577,9 @@ export const vertegenwoordigerValidationSchema = Joi.object({
   'e-mail': Joi.string().empty('').email({ tlds: false }).required().messages({
     'string.email': 'Geef een geldig e-mailadres in.',
   }),
-  telefoon: Joi.string()
-    .empty('')
-    .regex(/^(tel:)?\+?[0-9]*$/)
-    .optional()
-    .messages({
-      'string.pattern.base': 'Enkel een plusteken en cijfers zijn toegelaten.',
-    }),
+  telefoon: Joi.string().empty('').regex(phoneRegex).optional().messages({
+    'string.pattern.base': 'Enkel een plusteken en cijfers zijn toegelaten.',
+  }),
   socialMedia: Joi.string()
     .empty('')
     .uri()

--- a/tests/integration/components/phone-input-test.gts
+++ b/tests/integration/components/phone-input-test.gts
@@ -1,0 +1,69 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-verenigingen-loket/tests/helpers';
+import { render, settled } from '@ember/test-helpers';
+import PhoneInput from 'frontend-verenigingen-loket/components/phone-input';
+import { trackedObject } from '@ember/reactive/collections';
+
+module('Integration | Component | phone-input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it can display a warning message if the phone number is potentially invalid', async function (assert) {
+    const state = trackedObject<{ value: string | undefined }>();
+    await render(
+      <template>
+        <PhoneInput @value={{state.value}} as |phone|>
+          {{#if phone.warning}}
+            <div data-warning-message>{{phone.warning}}</div>
+          {{/if}}
+        </PhoneInput>
+      </template>,
+    );
+
+    assert
+      .dom('[data-warning-message]')
+      .doesNotExist('not providing a value should not display a warning');
+
+    state.value = '';
+    await settled();
+    assert
+      .dom('[data-warning-message]')
+      .doesNotExist('providing an empty string should not display a warning');
+
+    state.value = '1234';
+    await settled();
+    assert
+      .dom('[data-warning-message]')
+      .exists()
+      .containsText('Dit telefoonnummer lijkt ongebruikelijk kort.');
+
+    state.value = '1234567890123';
+    await settled();
+    assert
+      .dom('[data-warning-message]')
+      .exists()
+      .containsText('Dit telefoonnummer lijkt ongebruikelijk lang.');
+
+    state.value = '0411223344';
+    await settled();
+    assert
+      .dom('[data-warning-message]')
+      .exists()
+      .containsText('Gebruik bij voorkeur de internationale notatie.');
+
+    state.value = '+32411223344';
+    await settled();
+    assert
+      .dom('[data-warning-message]')
+      .doesNotExist(
+        'international notation numbers should not display a warning',
+      );
+
+    state.value = '+32 411 22 33 44';
+    await settled();
+    assert
+      .dom('[data-warning-message]')
+      .doesNotExist(
+        'white space should be ignored when checking the length of a number',
+      );
+  });
+});

--- a/tests/unit/validations/contactgegeven-test.ts
+++ b/tests/unit/validations/contactgegeven-test.ts
@@ -79,9 +79,15 @@ module('Unit | Validation | Contactgegeven', function () {
           waarde: '+32123456789',
         });
 
+        // White space is allowed
+        await validate(contactgegevenValidationSchema, {
+          ...contactgegevenBase,
+          waarde: '+32 12 345 67 89',
+        });
+
         assert.step('no error');
       } catch {
-        assert.step('no error');
+        assert.step('error');
       }
 
       assert.verifySteps(['no error']);


### PR DESCRIPTION
The Verenigingsregister API considers white space in phone numbers valid, so we need to adjust our code to support that. This prevents false positive warning and validation messages.

**Test instructions**

- Proxy to dev or qa and find a phone number that contains spaces (in the actual API response, not the UI)
- verify that it doesn't display a false positive warning if it's too long because of the spaces
- verify that it doesn't display a false positive validation error when saving (this _will_ override the formatting since we always strip the spaces due to the inputmask)