### PR TITLE
[CLBV-1207] Improve the contact address validations

### DIFF
--- a/app/components/address-search.gts
+++ b/app/components/address-search.gts
@@ -27,7 +27,8 @@ import {
 interface AddressSearchSignature {
   Args: {
     adres: TrackedData<Partial<Adres & AdresIdentifier>>;
-    errorMessage?: string;
+    error?: boolean;
+    required?: boolean;
   };
   Blocks: {
     default: [
@@ -118,7 +119,8 @@ export default class AddressSearch extends Component<AddressSearchSignature> {
           AddressRegisterSelector
           adres=@adres
           onChange=this.handleAddressChange
-          error=(if @errorMessage true false)
+          error=@error
+          required=@required
         )
         BusNumber=(component
           BusNumberSelector
@@ -141,6 +143,7 @@ interface AddressRegisterSelectorSignature {
     adres: TrackedData<Partial<Adres & AdresIdentifier>>;
     error?: boolean;
     id?: string;
+    required?: boolean;
     onChange: (data: { addresses: Address[] } | null) => void;
   };
 }
@@ -161,6 +164,10 @@ class AddressRegisterSelector extends Component<AddressRegisterSelectorSignature
 
       this.addressSuggestion = addressSuggestion as Address;
     }
+  }
+
+  get allowClear() {
+    return !this.args.required;
   }
 
   selectSuggestion = task(async (addressSuggestion: Address | null) => {
@@ -202,7 +209,7 @@ class AddressRegisterSelector extends Component<AddressRegisterSelectorSignature
     <div class={{if @error "ember-power-select--error"}}>
       <PowerSelect
         @triggerId={{@id}}
-        @allowClear={{true}}
+        @allowClear={{this.allowClear}}
         @renderInPlace={{false}}
         @search={{this.search.perform}}
         @selected={{this.addressSuggestion}}

--- a/app/routes/association/contact-details/edit.ts
+++ b/app/routes/association/contact-details/edit.ts
@@ -65,6 +65,7 @@ export default class AssociationContactDetailsEditRoute extends Route {
     return {
       contactgegevens: trackedArray(contactgegevens),
       locatie: correspondenceLocatie,
+      locaties,
       adres,
     };
   }

--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -77,11 +77,22 @@ export default class ContactEdit extends Component<ContactEditSignature> {
   @service declare toaster: ToasterService;
   contactgegevensToRemove: TrackedData<Partial<Contactgegeven>>[] = [];
 
+  get model() {
+    // We use the controller's model to work around an Ember bug: https://github.com/emberjs/ember.js/issues/18987
+    return this.args.controller.model;
+  }
+
   @cached
   get isLoading() {
-    // We use the controller's model to work around an Ember bug: https://github.com/emberjs/ember.js/issues/18987
-    const state = getPromiseState(this.args.controller.model.dataPromise);
+    const state = getPromiseState(this.model.dataPromise);
     return state.isPending;
+  }
+
+  get data() {
+    const state = getPromiseState(this.model.dataPromise);
+    assert('async data was accessed before it was loaded', state.isSuccess);
+
+    return state.value;
   }
 
   get association() {
@@ -89,24 +100,25 @@ export default class ContactEdit extends Component<ContactEditSignature> {
   }
 
   get contactgegevens() {
-    // We use the controller's model to work around an Ember bug: https://github.com/emberjs/ember.js/issues/18987
-    const state = getPromiseState(this.args.controller.model.dataPromise);
+    const state = getPromiseState(this.model.dataPromise);
 
     return state.isSuccess ? state.value.contactgegevens : [];
   }
 
   get locatie() {
-    // We use the controller's model to work around an Ember bug: https://github.com/emberjs/ember.js/issues/18987
-    const state = getPromiseState(this.args.controller.model.dataPromise);
-    assert('locatie was accessed before it was loaded', state.isSuccess);
-    return state.value.locatie;
+    return this.data.locatie;
+  }
+
+  get locaties() {
+    return this.data.locaties;
   }
 
   get adres() {
-    // We use the controller's model to work around an Ember bug: https://github.com/emberjs/ember.js/issues/18987
-    const state = getPromiseState(this.args.controller.model.dataPromise);
-    assert('adres was accessed before it was loaded', state.isSuccess);
-    return state.value.adres;
+    return this.data.adres;
+  }
+
+  get isAdresRequired() {
+    return this.locaties.length <= 1 && !this.adres.isNew;
   }
 
   save = dropTask(async (event: Event) => {
@@ -126,14 +138,14 @@ export default class ContactEdit extends Component<ContactEditSignature> {
 
     const adres = this.adres;
     const shouldValidateAddress =
-      !isEmptyAdres(adres.data) && !adres.data.bronwaarde;
+      this.isAdresRequired || !isEmptyAdres(adres.data);
 
     if (shouldValidateAddress) {
       await validateData(adres, adresValidationSchema);
+    }
 
-      if (adres.hasErrors) {
-        return;
-      }
+    if (adres.hasErrors) {
+      return;
     }
 
     try {
@@ -283,7 +295,7 @@ export default class ContactEdit extends Component<ContactEditSignature> {
           </div>
         </section>
 
-        <AddressEdit @adres={{this.adres}} />
+        <AddressEdit @adres={{this.adres}} @required={{this.isAdresRequired}} />
       </div>
 
       <form id="contact-details-edit-form" {{on "submit" this.save.perform}}>
@@ -338,6 +350,7 @@ export default class ContactEdit extends Component<ContactEditSignature> {
 interface AddressEditSignature {
   Args: {
     adres: TrackedData<Partial<Adres & AdresIdentifier>>;
+    required?: boolean;
   };
 }
 class AddressEdit extends Component<AddressEditSignature> {
@@ -347,6 +360,10 @@ class AddressEdit extends Component<AddressEditSignature> {
     super(owner, args);
 
     this.determineInitialInputMode();
+  }
+
+  get isRequired() {
+    return this.args.required || this.isManualInputMode;
   }
 
   get isManualInputMode() {
@@ -366,6 +383,7 @@ class AddressEdit extends Component<AddressEditSignature> {
   switchToSearchMode = () => {
     this.isSearchMode = true;
     clearAdresValues(this.args.adres.data);
+    this.args.adres.clearErrors();
   };
 
   switchToManualInputMode = () => {
@@ -373,6 +391,7 @@ class AddressEdit extends Component<AddressEditSignature> {
 
     const adres = this.args.adres;
     adres.data.bronwaarde = undefined;
+    adres.clearErrors();
     if (!adres.data.land) {
       adres.data.land = BELGIUM;
     }
@@ -380,19 +399,29 @@ class AddressEdit extends Component<AddressEditSignature> {
 
   <template>
     <section>
-      <EditCard @containsRequiredFields={{this.isManualInputMode}}>
+      <EditCard @containsRequiredFields={{this.isRequired}}>
         <:title>
           Correspondentieadres
         </:title>
         <:card as |Card|>
           {{#if this.isSearchMode}}
-            <AddressSearch @adres={{@adres}} as |address|>
+            <AddressSearch
+              @adres={{@adres}}
+              @error={{@adres.hasErrors}}
+              @required={{this.isRequired}}
+              as |address|
+            >
               <Card.Columns>
                 <:left as |Item|>
-                  <Item>
+                  <Item @required={{this.isRequired}}>
                     <:label>Adres</:label>
                     <:content>
                       <address.Search />
+                      {{#if @adres.hasErrors}}
+                        <AuHelpText @error={{true}}>
+                          Dit veld is verplicht.
+                        </AuHelpText>
+                      {{/if}}
                       <AuButton
                         @skin="link"
                         {{on "click" this.switchToManualInputMode}}


### PR DESCRIPTION
The verenigingsregister API requires that there is at least 1 location linked to an association. This means we can't allow users to delete the correspondence address if it's the last location.

**Test instructions**
- Go to the contact detail edit page of an association with only a single location (which is also the correspondence address)
- verify that you can't leave the fields empty (search mode and manual input mode)
- Go to the contact detail edit page of an association with more than one location and verify that you can still remove the correspondence address.