### PR TITLE
[CLBV-1209] Contactgegevens validation improvements

### DIFF
--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -39,6 +39,7 @@ import {
   CONTACTGEGEVEN_LABEL,
   type AdresIdentifier,
   type Adres,
+  ApiValidationError,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister';
 import type RouterService from '@ember/routing/router-service';
 import type StoreService from 'frontend-verenigingen-loket/services/store';
@@ -62,6 +63,7 @@ import {
   isPostcodeInFlanders,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister/adres';
 import { phoneRegex } from 'frontend-verenigingen-loket/utils/validations/phone';
+import AuAlert from '@appuniversum/ember-appuniversum/components/au-alert';
 import { emailRegex } from 'frontend-verenigingen-loket/utils/validations/email';
 
 interface ContactEditSignature {
@@ -123,8 +125,21 @@ export default class ContactEdit extends Component<ContactEditSignature> {
     return this.locaties.length <= 1 && !this.adres.isNew;
   }
 
+  get genericValidationError() {
+    const withGenericError = this.contactgegevens.find((contactgegeven) =>
+      contactgegeven.hasError('genericError'),
+    );
+
+    return withGenericError ? withGenericError.errors.genericError : undefined;
+  }
+
   save = dropTask(async (event: Event) => {
     event.preventDefault();
+
+    // clear the generic error messages we received from the server previously
+    this.contactgegevens.forEach((contactgegeven) =>
+      contactgegeven.removeError('genericError'),
+    );
 
     const promises = this.contactgegevens.map(async (contactgegeven) => {
       await validateData(contactgegeven, contactgegevenValidationSchema);
@@ -177,18 +192,9 @@ export default class ContactEdit extends Component<ContactEditSignature> {
       ];
 
       for (const contactgegeven of sortedContactgegevensToSave) {
-        const changedData: Partial<
-          Record<keyof Contactgegeven, Contactgegeven[keyof Contactgegeven]>
-        > = {};
-
-        for (const value of contactgegeven.changedValues) {
-          changedData[value] = contactgegeven.data[value];
-        }
-
         await createOrUpdateContactgegeven({
           vCode,
-          contactgegevenId: contactgegeven.data.contactgegevenId,
-          data: changedData as Partial<Contactgegeven>,
+          contactgegeven: contactgegeven,
         });
       }
 
@@ -210,7 +216,7 @@ export default class ContactEdit extends Component<ContactEditSignature> {
       await waitForStableAPI();
       this.router.transitionTo('association.contact-details');
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof Error && !(error instanceof ApiValidationError)) {
         handleError(this.toaster, error);
       }
     }
@@ -278,7 +284,7 @@ export default class ContactEdit extends Component<ContactEditSignature> {
           </div>
 
           <div>
-            <AuButtonGroup class="au-c-button-group--align-right">
+            <AuButtonGroup class="au-u-flex au-u-flex--end">
               <AuLink
                 @route="association.contact-details"
                 @skin="button-secondary"
@@ -294,6 +300,17 @@ export default class ContactEdit extends Component<ContactEditSignature> {
                 Opslaan
               </AuButton>
             </AuButtonGroup>
+            {{#if this.genericValidationError}}
+              <AuAlert
+                @skin="error"
+                @size="small"
+                @icon="info-circle"
+                @closable={{true}}
+                class="au-u-margin-top-small au-u-max-width-xsmall"
+              >
+                {{this.genericValidationError}}
+              </AuAlert>
+            {{/if}}
           </div>
         </section>
 
@@ -594,7 +611,10 @@ class TableRow extends Component<TableRowSignature> {
   }
 
   <template>
-    <tr>
+    <tr
+      class="c-edit-table-row
+        {{~if @contactgegeven.errors.genericError ' c-edit-table-row--error'}}"
+    >
       <td>
         <ContactTypeSelect
           @contactgegeven={{@contactgegeven}}

--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -62,6 +62,7 @@ import {
   isPostcodeInFlanders,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister/adres';
 import { phoneRegex } from 'frontend-verenigingen-loket/utils/validations/phone';
+import { emailRegex } from 'frontend-verenigingen-loket/utils/validations/email';
 
 interface ContactEditSignature {
   Args: {
@@ -838,10 +839,9 @@ export const contactgegevenValidationSchema = Joi.object({
       switch: [
         {
           is: 'E-mail' satisfies ContactgegevenType,
-          then: Joi.string()
-            .required()
-            .email({ tlds: false })
-            .messages({ 'string.email': 'Geef een geldig e-mailadres in.' }),
+          then: Joi.string().required().regex(emailRegex).messages({
+            'string.pattern.base': 'Geef een geldig e-mailadres in.',
+          }),
         },
         {
           is: 'Telefoon' satisfies ContactgegevenType,

--- a/app/utils/validations/email.ts
+++ b/app/utils/validations/email.ts
@@ -1,0 +1,4 @@
+// This is the exact regex that the Verenigingsregister API uses, so it should match their server side validation.
+// More info: https://vlaamseoverheid.atlassian.net/wiki/spaces/AGB/pages/6336155052/Contactgegevens+-+Als+GI+wil+ik+de+contactgegevens+van+een+vereniging+beheren#Business-regels
+export const emailRegex =
+  /^([_-]*([a-z0-9]+[.!#$%&'*+/=?^_`{|}~-]?){1,}[_-]*)@(([a-z0-9]+[.-]?)*[a-z0-9]\.)+[a-z]{2,}$/;

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -66,6 +66,10 @@ export type Contactgegeven = {
   contactgegeventype: ContactgegevenType;
   waarde: string;
   isPrimair: boolean;
+} & {
+  // Not a real property, but we use it to store generic errors for now.
+  // TODO: This is only relevant for the edit page, we shouldn't add it here.
+  genericError?: string;
 };
 
 // A representative in English. We use dutch naming here since it's a verenigingsregister object that also uses dutch property names.
@@ -285,26 +289,52 @@ export async function getVertegenwoordigers(
 
 export async function createOrUpdateContactgegeven({
   vCode,
-  contactgegevenId,
-  data,
+  contactgegeven,
 }: {
   vCode: string;
-  contactgegevenId?: number;
-  data: Partial<Contactgegeven>;
+  contactgegeven: TrackedData<Partial<Contactgegeven>>;
 }) {
+  const contactgegevenId = contactgegeven.data.contactgegevenId;
   const url = buildContactgegevenUrl(vCode, contactgegevenId);
   const method = contactgegevenId ? 'PATCH' : 'POST';
 
-  await manager.request({
-    url,
-    method,
-    headers: new Headers({
-      'Content-Type': 'application/json',
-    }),
-    body: JSON.stringify({
-      contactgegeven: data,
-    }),
-  });
+  const changedData: Partial<
+    Record<keyof Contactgegeven, Contactgegeven[keyof Contactgegeven]>
+  > = {};
+
+  for (const value of contactgegeven.changedValues) {
+    changedData[value] = contactgegeven.data[value];
+  }
+
+  try {
+    await manager.request({
+      url,
+      method,
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+      body: JSON.stringify({
+        contactgegeven: changedData,
+      }),
+    });
+  } catch (error) {
+    // TODO: use the correct error type, not sure if WarpDrive exports this
+    // @ts-expect-error: Find out where to get proper types for this error: https://github.com/warp-drive-data/warp-drive/blob/7f899457cea393b233b86a4d92c9f5bd4a51ea76/warp-drive-packages/core/src/request/-private/fetch.ts#L249-L258
+    if (error instanceof Error && error.status === 400) {
+      // @ts-expect-error: missing error types
+      const apiError = error.content as ApiErrorResponse;
+
+      if (apiError.details) {
+        // All "detail" values seem to contain a `Source: ` prefix, which we don't want to show to users..
+        const errorMessage = apiError.details.detail.replace('Source: ', '');
+        contactgegeven.addError('genericError', errorMessage);
+      }
+
+      throw new ApiValidationError(contactgegeven);
+    } else {
+      throw error;
+    }
+  }
 }
 
 export async function deleteContactgegeven(

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -8,6 +8,7 @@ import { isValidRijksregisternummer } from 'frontend-verenigingen-loket/utils/ri
 import type TrackedData from 'frontend-verenigingen-loket/utils/tracked-data';
 import Joi from 'joi';
 import { phoneRegex } from './validations/phone';
+import { emailRegex } from './validations/email';
 
 const manager = new RequestManager().use([Fetch]);
 
@@ -574,8 +575,8 @@ export const vertegenwoordigerValidationSchema = Joi.object({
     .messages({
       'string.invalid-ssn': 'Geen geldig rijksregisternummer.',
     }),
-  'e-mail': Joi.string().empty('').email({ tlds: false }).required().messages({
-    'string.email': 'Geef een geldig e-mailadres in.',
+  'e-mail': Joi.string().empty('').regex(emailRegex).required().messages({
+    'string.pattern.base': 'Geef een geldig e-mailadres in.',
   }),
   telefoon: Joi.string().empty('').regex(phoneRegex).optional().messages({
     'string.pattern.base': 'Enkel een plusteken en cijfers zijn toegelaten.',

--- a/tests/unit/validations/contactgegeven-test.ts
+++ b/tests/unit/validations/contactgegeven-test.ts
@@ -30,6 +30,13 @@ module('Unit | Validation | Contactgegeven', function () {
           waarde: 'not-an-email',
         }),
       );
+
+      await assert.rejects(
+        validate(contactgegevenValidationSchema, {
+          ...contactgegevenBase,
+          waarde: 'email.with@numbers.be123',
+        }),
+      );
     });
 
     test('valid email', async function (assert) {


### PR DESCRIPTION
- update the email validation logic so it uses the same regex as the backend
- display a generic validation error, similar to the representatives setup