### PR TITLE
[CLBV-1213] Prevent users from editing KBO contact data

### DIFF
--- a/app/components/edit-table.gts
+++ b/app/components/edit-table.gts
@@ -46,7 +46,7 @@ interface EditCellSignature {
 
 export type YieldedCellInput = WithBoundArgs<
   typeof CellInput,
-  'id' | 'error' | 'warning'
+  'id' | 'error' | 'warning' | 'disabled'
 >;
 
 export class EditCell extends Component<EditCellSignature> {
@@ -86,6 +86,7 @@ interface CellInputSignature {
     error?: boolean;
     warning?: boolean;
     id: string;
+    disabled?: boolean;
   };
   Element: AuInputSignature['Element'];
 }
@@ -95,6 +96,7 @@ const CellInput = <template>
     @width={{@width}}
     @error={{@error}}
     @warning={{@warning}}
+    @disabled={{@disabled}}
     id={{@id}}
     ...attributes
   />

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -71,3 +71,7 @@
 .u-link-xs {
   font-size: 1.4rem;
 }
+
+.u-align-middle {
+  vertical-align: middle !important;
+}

--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -338,6 +338,7 @@ export default class ContactEdit extends Component<ContactEditSignature> {
             {{#each this.contactgegevens as |contactgegeven|}}
               <TableRow
                 @contactgegeven={{contactgegeven}}
+                @contactgegevens={{this.contactgegevens}}
                 @onDelete={{this.deleteContactgegeven}}
                 @onPrimaryChange={{this.handlePrimaryChange}}
               />
@@ -583,11 +584,32 @@ const AddressInput = <template>
 interface TableRowSignature {
   Args: {
     contactgegeven: TrackedData<Partial<Contactgegeven>>;
+    contactgegevens: TrackedData<Partial<Contactgegeven>>[];
     onPrimaryChange: (contactgegeven: TrackedData<Contactgegeven>) => void;
     onDelete: (contactgegeven: TrackedData<Contactgegeven>) => void;
   };
 }
 class TableRow extends Component<TableRowSignature> {
+  get disabled() {
+    return this.args.contactgegeven.data.bron === 'KBO';
+  }
+
+  get primaryDisabled() {
+    if (this.disabled) {
+      return true;
+    }
+
+    const currentType = this.args.contactgegeven.data.contactgegeventype;
+    // If there is a KBO contactgegeven with the same type, that is also primary, we can't allow primary edits. That would change the KBO data because there can only be a single primary per type.
+    return this.args.contactgegevens.some((contactgegeven) => {
+      return (
+        contactgegeven.data.contactgegeventype === currentType &&
+        contactgegeven.data.bron === 'KBO' &&
+        contactgegeven.data.isPrimair
+      );
+    });
+  }
+
   get editComponent() {
     if (!this.args.contactgegeven.data.contactgegeventype) {
       return NoContactType;
@@ -619,11 +641,14 @@ class TableRow extends Component<TableRowSignature> {
         <ContactTypeSelect
           @contactgegeven={{@contactgegeven}}
           @errorMessage={{@contactgegeven.errors.contactgegeventype}}
+          @disabled={{this.disabled}}
         />
       </td>
       <this.editComponent
         @contactgegeven={{@contactgegeven}}
         @onPrimaryChange={{fn @onPrimaryChange @contactgegeven}}
+        @disabled={{this.disabled}}
+        @primaryDisabled={{this.primaryDisabled}}
       />
       <td class="au-u-text-right">
         <AuButton
@@ -631,6 +656,7 @@ class TableRow extends Component<TableRowSignature> {
           @hideText={{true}}
           @icon="bin"
           @skin="naked"
+          @disabled={{this.disabled}}
           {{on "click" (fn @onDelete @contactgegeven)}}
         >Verwijder contactgegeven</AuButton>
       </td>
@@ -642,6 +668,7 @@ interface ContactTypeSelectSignature {
   Args: {
     contactgegeven: TrackedData<Partial<Contactgegeven>>;
     errorMessage?: string;
+    disabled?: boolean;
   };
 }
 class ContactTypeSelect extends Component<ContactTypeSelectSignature> {
@@ -657,9 +684,11 @@ class ContactTypeSelect extends Component<ContactTypeSelectSignature> {
   }
 
   get isDisabled() {
-    return !(
-      this.args.contactgegeven.isNew ||
-      !this.args.contactgegeven.data.contactgegeventype
+    return (
+      !(
+        this.args.contactgegeven.isNew ||
+        !this.args.contactgegeven.data.contactgegeventype
+      ) || this.args.disabled
     );
   }
 
@@ -699,6 +728,8 @@ class ContactTypeSelect extends Component<ContactTypeSelectSignature> {
 interface EditFieldSignature {
   Args: {
     contactgegeven: TrackedData<Partial<Contactgegeven>>;
+    disabled?: boolean;
+    primaryDisabled?: boolean;
     onPrimaryChange: (value: boolean) => void;
   };
 }
@@ -708,6 +739,8 @@ const EmailEdit = <template>
     @contactgegeven={{@contactgegeven}}
     @onPrimaryChange={{@onPrimaryChange}}
     @errorMessage={{@contactgegeven.errors.waarde}}
+    @disabled={{@disabled}}
+    @primaryDisabled={{@primaryDisabled}}
   >
     <:input as |ContactInput|>
       <ContactInput
@@ -732,11 +765,13 @@ const TelephoneEdit = <template>
         @onPrimaryChange={{@onPrimaryChange}}
         @errorMessage={{errorMessage}}
         @warningMessage={{phone.warning}}
+        @disabled={{@disabled}}
       >
         <:input as |_ id|>
           <phone.Input
             @width="block"
             @error={{if errorMessage true}}
+            @disabled={{@disabled}}
             id={{id}}
           />
         </:input>
@@ -751,6 +786,7 @@ const SocialMediaEdit = <template>
     @contactgegeven={{@contactgegeven}}
     @onPrimaryChange={{@onPrimaryChange}}
     @errorMessage={{@contactgegeven.errors.waarde}}
+    @disabled={{@disabled}}
   >
     <:input as |ContactInput|>
       <ContactInput
@@ -768,6 +804,7 @@ const WebsiteEdit = <template>
     @contactgegeven={{@contactgegeven}}
     @onPrimaryChange={{@onPrimaryChange}}
     @errorMessage={{@contactgegeven.errors.waarde}}
+    @disabled={{@disabled}}
   >
     <:input as |ContactInput|>
       <ContactInput
@@ -785,6 +822,8 @@ interface EditColumnsSignature {
     contactgegeven: TrackedData<Partial<Contactgegeven>>;
     errorMessage?: string;
     warningMessage?: string;
+    disabled?: boolean;
+    primaryDisabled?: boolean;
     onPrimaryChange?: (newValue: boolean) => void;
   };
   Blocks: {
@@ -804,6 +843,10 @@ class EditColumns extends Component<EditColumnsSignature> {
     ];
   }
 
+  get primaryDisabled() {
+    return this.args.disabled || this.args.primaryDisabled;
+  }
+
   <template>
     <EditCell
       @errorMessage={{@errorMessage}}
@@ -813,7 +856,7 @@ class EditColumns extends Component<EditColumnsSignature> {
         {{this.label}}
       </:label>
       <:input as |CellInput id|>
-        {{yield CellInput id to="input"}}
+        {{yield (component CellInput disabled=@disabled) id to="input"}}
       </:input>
     </EditCell>
     <td>
@@ -821,6 +864,7 @@ class EditColumns extends Component<EditColumnsSignature> {
         <AuCheckbox
           @checked={{@contactgegeven.data.isPrimair}}
           @onChange={{@onPrimaryChange}}
+          @disabled={{this.primaryDisabled}}
         >
           {{yield to="checkboxLabel"}}
         </AuCheckbox>

--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -3,11 +3,13 @@ import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
 import AuCheckbox from '@appuniversum/ember-appuniversum/components/au-checkbox';
 import AuHeading from '@appuniversum/ember-appuniversum/components/au-heading';
 import AuHelpText from '@appuniversum/ember-appuniversum/components/au-help-text';
+import AuIcon from '@appuniversum/ember-appuniversum/components/au-icon';
 import AuInput, {
   type AuInputSignature,
 } from '@appuniversum/ember-appuniversum/components/au-input';
 import AuLoader from '@appuniversum/ember-appuniversum/components/au-loader';
 import AuLink from '@appuniversum/ember-appuniversum/components/au-link';
+import AuTooltip from '@appuniversum/ember-appuniversum/components/au-tooltip';
 import { fn } from '@ember/helper';
 import { on } from '@ember/modifier';
 import { service } from '@ember/service';
@@ -650,15 +652,27 @@ class TableRow extends Component<TableRowSignature> {
         @disabled={{this.disabled}}
         @primaryDisabled={{this.primaryDisabled}}
       />
-      <td class="au-u-text-right">
-        <AuButton
-          @alert={{true}}
-          @hideText={{true}}
-          @icon="bin"
-          @skin="naked"
-          @disabled={{this.disabled}}
-          {{on "click" (fn @onDelete @contactgegeven)}}
-        >Verwijder contactgegeven</AuButton>
+      <td class="au-u-text-center u-align-middle">
+        {{#if this.disabled}}
+          <AuTooltip @placement="left" as |tooltip|>
+            <span class="au-u-muted" {{tooltip.target}}>
+              <AuIcon @icon="info-circle" @size="large" />
+            </span>
+            <tooltip.Content>
+              Contactgegevens die uit KBO werden overgenomen, kunnen niet
+              aangepast worden.
+            </tooltip.Content>
+          </AuTooltip>
+        {{else}}
+          <AuButton
+            @alert={{true}}
+            @hideText={{true}}
+            @icon="bin"
+            @skin="naked"
+            @disabled={{this.disabled}}
+            {{on "click" (fn @onDelete @contactgegeven)}}
+          >Verwijder contactgegeven</AuButton>
+        {{/if}}
       </td>
     </tr>
   </template>

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -61,7 +61,10 @@ export type ContactgegevenType =
   | 'Website'
   | 'SocialMedia';
 
+export type ContactgegevenBron = 'Initiator' | 'KBO';
+
 export type Contactgegeven = {
+  bron: ContactgegevenBron;
   contactgegevenId: number;
   contactgegeventype: ContactgegevenType;
   waarde: string;
@@ -250,6 +253,7 @@ export function getContactgegevensFromVereniging(
     vereniging.contactgegevens?.map((contactgegeven) => {
       // We only return the data we actually need. The API responds with more (nested) data.
       return {
+        bron: contactgegeven.bron,
         contactgegevenId: contactgegeven.contactgegevenId,
         contactgegeventype: contactgegeven.contactgegeventype,
         waarde: contactgegeven.waarde,


### PR DESCRIPTION
Some data originates from the KBO, which users are not allowed to edit.

**Test instructions**
- proxy to dev or qa
- log in as Brugge
- find an association that has contact data originating from the KBO (I used "Klauwende Koningen")
- verify that the data can no longer be edited