### PR TITLE
[CLBV-1211] Disable representative editing for KBO organizations

### DIFF
--- a/app/routes/association.ts
+++ b/app/routes/association.ts
@@ -7,7 +7,10 @@ import type Transition from '@ember/routing/transition';
 import type Association from 'frontend-verenigingen-loket/models/association';
 import type CurrentAssociationService from 'frontend-verenigingen-loket/services/current-association';
 import type StoreService from 'frontend-verenigingen-loket/services/store';
-import { hasApiAuthorization } from 'frontend-verenigingen-loket/utils/verenigingsregister';
+import {
+  getVerenigingDetails,
+  hasApiAuthorization,
+} from 'frontend-verenigingen-loket/utils/verenigingsregister';
 
 export default class AssociationRoute extends Route {
   @service declare session: SessionService;
@@ -42,8 +45,12 @@ export default class AssociationRoute extends Route {
       } catch {
         hasAuthorization = false;
       }
+
+      const vereniging = (await getVerenigingDetails(association)).vereniging;
+
       return {
         association,
+        vereniging,
         kboNumber: await this.loadKboNumber(association),
         hasApiAuthorization: hasAuthorization,
       };

--- a/app/routes/association/representatives/edit.ts
+++ b/app/routes/association/representatives/edit.ts
@@ -9,6 +9,7 @@ import type SensitiveData from 'frontend-verenigingen-loket/services/sensitive-d
 import type Store from 'frontend-verenigingen-loket/services/store';
 import {
   getVertegenwoordigers,
+  isKboData,
   logAPIError,
   type Vertegenwoordiger,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister';
@@ -24,17 +25,22 @@ export default class AssociationRepresentativesEditRoute extends Route {
   @service declare router: RouterService;
 
   beforeModel() {
-    const { hasApiAuthorization } = this.modelFor('association') as NonNullable<
-      ModelFrom<AssociationRoute>
-    >;
+    const { vereniging, hasApiAuthorization } = this.modelFor(
+      'association',
+    ) as NonNullable<ModelFrom<AssociationRoute>>;
 
     if (
       this.sensitiveData.requiresReason(this.currentAssociation.association) &&
       this.currentSession.hasApiClient &&
-      hasApiAuthorization
+      hasApiAuthorization &&
+      !isKboData(vereniging)
     ) {
       this.router.transitionTo('association.representatives.access-reason');
-    } else if (!this.currentSession.hasApiClient || !hasApiAuthorization) {
+    } else if (
+      !this.currentSession.hasApiClient ||
+      !hasApiAuthorization ||
+      isKboData(vereniging)
+    ) {
       this.router.transitionTo('association.representatives');
     }
   }

--- a/app/routes/association/representatives/index.ts
+++ b/app/routes/association/representatives/index.ts
@@ -31,12 +31,13 @@ export default class AssociationRepresentativesRoute extends Route {
 
   model() {
     const association = this.currentAssociation.association;
-    const { kboNumber, hasApiAuthorization } = this.modelFor(
+    const { kboNumber, hasApiAuthorization, vereniging } = this.modelFor(
       'association',
     ) as NonNullable<ModelFrom<AssociationRoute>>;
 
     return {
       association,
+      vereniging,
       kboNumber,
       hasApiAuthorization,
     };

--- a/app/templates/association/contact-details/edit.gts
+++ b/app/templates/association/contact-details/edit.gts
@@ -42,6 +42,7 @@ import {
   type AdresIdentifier,
   type Adres,
   ApiValidationError,
+  isKboData,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister';
 import type RouterService from '@ember/routing/router-service';
 import type StoreService from 'frontend-verenigingen-loket/services/store';
@@ -593,7 +594,7 @@ interface TableRowSignature {
 }
 class TableRow extends Component<TableRowSignature> {
   get disabled() {
-    return this.args.contactgegeven.data.bron === 'KBO';
+    return isKboData(this.args.contactgegeven.data);
   }
 
   get primaryDisabled() {
@@ -606,7 +607,7 @@ class TableRow extends Component<TableRowSignature> {
     return this.args.contactgegevens.some((contactgegeven) => {
       return (
         contactgegeven.data.contactgegeventype === currentType &&
-        contactgegeven.data.bron === 'KBO' &&
+        isKboData(contactgegeven.data) &&
         contactgegeven.data.isPrimair
       );
     });

--- a/app/templates/association/representatives/index.gts
+++ b/app/templates/association/representatives/index.gts
@@ -17,6 +17,7 @@ import ErrorTableMessage from 'frontend-verenigingen-loket/components/table-mess
 import telFormat from 'frontend-verenigingen-loket/helpers/tel-format';
 import {
   getVertegenwoordigers,
+  isKboData,
   logAPIError,
   type Vertegenwoordiger,
 } from 'frontend-verenigingen-loket/utils/verenigingsregister';
@@ -28,6 +29,8 @@ import type AssociationRepresentativesIndexController from 'frontend-vereniginge
 import { cached } from '@glimmer/tracking';
 import type Association from 'frontend-verenigingen-loket/models/association';
 import type SensitiveDataService from 'frontend-verenigingen-loket/services/sensitive-data';
+import AuButton from '@appuniversum/ember-appuniversum/components/au-button';
+import AuHelpText from '@appuniversum/ember-appuniversum/components/au-help-text';
 
 interface Signature {
   Args: {
@@ -56,6 +59,12 @@ export default class RepresentativesIndex extends Component<Signature> {
     );
   }
 
+  get canEdit() {
+    return (
+      this.currentSession.canEdit && !isKboData(this.args.model.vereniging)
+    );
+  }
+
   reloadData = () => {
     this.router.refresh('association.representatives.index');
   };
@@ -74,7 +83,7 @@ export default class RepresentativesIndex extends Component<Signature> {
 
         {{#if this.canSeeVertegenwoordigers}}
           <div class="au-u-flex au-u-flex--column au-u-flex--vertical-end">
-            {{#if this.currentSession.canEdit}}
+            {{#if this.canEdit}}
               <AuLink
                 @route="association.representatives.edit"
                 @skin="button-secondary"
@@ -83,7 +92,17 @@ export default class RepresentativesIndex extends Component<Signature> {
                 Bewerk
               </AuLink>
             {{else}}
-              <ReportWrongData @model={{this.association}} />
+              {{#if (isKboData @model.vereniging)}}
+                <AuButton @skin="secondary" @icon="pencil" @disabled={{true}}>
+                  Bewerk
+                </AuButton>
+                <AuHelpText @skin="secondary" class="au-u-margin-bottom-small">
+                  Aan een KBO vereniging kunnen geen vertegenwoordigers
+                  toegevoegd worden.
+                </AuHelpText>
+              {{else}}
+                <ReportWrongData @model={{this.association}} />
+              {{/if}}
             {{/if}}
             <span class="au-u-margin-top-tiny">
               <LastUpdated @lastUpdated={{this.association.lastUpdated}} />

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -17,7 +17,9 @@ const manager = new RequestManager().use([Fetch]);
 ////////////////////////////////////////////////////////////////////////////
 
 // These types aren't complete. The API contains more info, but we only type what is useful to keep things simple.
+type Bron = 'Initiator' | 'KBO';
 type Vereniging = {
+  bron: Bron;
   vCode: string;
   naam: string;
   korteNaam: string;
@@ -61,10 +63,8 @@ export type ContactgegevenType =
   | 'Website'
   | 'SocialMedia';
 
-export type ContactgegevenBron = 'Initiator' | 'KBO';
-
 export type Contactgegeven = {
-  bron: ContactgegevenBron;
+  bron: Bron;
   contactgegevenId: number;
   contactgegeventype: ContactgegevenType;
   waarde: string;
@@ -623,3 +623,10 @@ export const vertegenwoordigerValidationSchema = Joi.object({
 }).messages({
   'any.required': 'Dit veld is verplicht.',
 });
+
+////////////////////////////////////////////////////////////////////////////
+// Utils
+////////////////////////////////////////////////////////////////////////////
+export function isKboData(data: { bron?: Bron }) {
+  return data.bron === 'KBO';
+}


### PR DESCRIPTION
Builds on the changes in #142 so draft until that is merged

**Test instructions**
- Proxy to DEV or QA
- log in as gemeente brugge
- filter on postcode 8000
- select a vereniging that is not a feitelijke vereniging (I used `Klauwende Koningen`)
- go to the vertegenwoordigers page
- verify that the edit button is disabled and displays some info text.