### PR TITLE
[CLBV-1251]: Add an extra field 'Mobiel nummer' for representatives

### DIFF
--- a/app/templates/association/representatives/edit.gjs
+++ b/app/templates/association/representatives/edit.gjs
@@ -267,6 +267,9 @@ export default class RepresentativesEdit extends Component {
               E-mail
             </th>
             <th>
+              Mobiel nummer
+            </th>
+            <th>
               Telefoonnummer
             </th>
             <th>
@@ -391,18 +394,35 @@ class EditRow extends Component {
         </:input>
       </EditCell>
       <PhoneInput
+        @onUpdate={{fn (mut @vertegenwoordiger.data.mobiel)}}
+        @value={{@vertegenwoordiger.data.mobiel}}
+        as |mobiel|
+      >
+        {{#let @contactPoint.errors.mobiel as |errorMessage|}}
+          <EditCell
+            @errorMessage={{errorMessage}}
+            @warningMessage={{mobiel.warning}}
+          >
+            <:label>Mobiel nummer</:label>
+            <:input as |_ id|>
+              <mobiel.Input @error={{if errorMessage true}} id={{id}} />
+            </:input>
+          </EditCell>
+        {{/let}}
+      </PhoneInput>
+      <PhoneInput
         @onUpdate={{fn (mut @vertegenwoordiger.data.telefoon)}}
         @value={{@vertegenwoordiger.data.telefoon}}
-        as |phone|
+        as |telefoon|
       >
         {{#let @contactPoint.errors.telefoon as |errorMessage|}}
           <EditCell
             @errorMessage={{errorMessage}}
-            @warningMessage={{phone.warning}}
+            @warningMessage={{telefoon.warning}}
           >
             <:label>Telefoonnummer</:label>
             <:input as |_ id|>
-              <phone.Input @error={{if errorMessage true}} id={{id}} />
+              <telefoon.Input @error={{if errorMessage true}} id={{id}} />
             </:input>
           </EditCell>
         {{/let}}

--- a/app/templates/association/representatives/index.gts
+++ b/app/templates/association/representatives/index.gts
@@ -224,6 +224,12 @@ class VertegenwoordigersData extends Component<VertegenwoordigersDataSignature> 
                 @class="data-table__header-title"
               />
               <AuDataTableThSortable
+                @field="mobiel"
+                @currentSorting={{@controller.sort}}
+                @label="Mobiel nummer"
+                @class="data-table__header-title"
+              />
+              <AuDataTableThSortable
                 @field="telefoon"
                 @currentSorting={{@controller.sort}}
                 @label="Telefoonnummer"
@@ -259,6 +265,15 @@ class VertegenwoordigersData extends Component<VertegenwoordigersDataSignature> 
                   <AuLinkExternal href="mailto:{{vertegenwoordiger.e-mail}}">
                     {{vertegenwoordiger.e-mail}}
                   </AuLinkExternal>
+                </td>
+                <td>
+                  {{#if vertegenwoordiger.mobiel}}
+                    <AuLinkExternal href="tel:{{vertegenwoordiger.mobiel}}">
+                      {{telFormat vertegenwoordiger.mobiel}}
+                    </AuLinkExternal>
+                  {{else}}
+                    -
+                  {{/if}}
                 </td>
                 <td>
                   {{#if vertegenwoordiger.telefoon}}

--- a/app/utils/verenigingsregister.ts
+++ b/app/utils/verenigingsregister.ts
@@ -84,6 +84,7 @@ export type Vertegenwoordiger = {
   roepnaam?: string;
   insz?: string;
   'e-mail'?: string;
+  mobiel?: string;
   telefoon?: string;
   socialMedia?: string;
   isPrimair?: boolean;
@@ -279,6 +280,7 @@ export async function getVertegenwoordigers(
         voornaam: vertegenwoordiger.voornaam,
         achternaam: vertegenwoordiger.achternaam,
         'e-mail': vertegenwoordiger['e-mail'],
+        mobiel: vertegenwoordiger.mobiel,
         telefoon: vertegenwoordiger.telefoon,
         socialMedia: vertegenwoordiger.socialMedia,
         isPrimair: vertegenwoordiger.isPrimair,
@@ -611,6 +613,9 @@ export const vertegenwoordigerValidationSchema = Joi.object({
     }),
   'e-mail': Joi.string().empty('').regex(emailRegex).optional().messages({
     'string.pattern.base': 'Geef een geldig e-mailadres in.',
+  }),
+  mobiel: Joi.string().empty('').regex(phoneRegex).optional().messages({
+    'string.pattern.base': 'Enkel een plusteken en cijfers zijn toegelaten.',
   }),
   telefoon: Joi.string().empty('').regex(phoneRegex).optional().messages({
     'string.pattern.base': 'Enkel een plusteken en cijfers zijn toegelaten.',

--- a/tests/unit/utils/verenigingsregister-test.ts
+++ b/tests/unit/utils/verenigingsregister-test.ts
@@ -209,6 +209,30 @@ module('Unit | Utility | verenigingsregister', function () {
         );
       });
 
+      test('mobiel', async function (assert) {
+        await assert.rejects(
+          validate(vertegenwoordigerValidationSchema, {
+            voornaam: 'Jan',
+            achternaam: 'Janssens',
+            'e-mail': 'jan.janssens@example.com',
+            mobiel: 'not-a-phone',
+          }),
+          /Enkel een plusteken en cijfers zijn toegelaten/,
+          'Invalid mobiel nummer should throw',
+        );
+
+        await assert.rejects(
+          validate(vertegenwoordigerValidationSchema, {
+            voornaam: 'Jan',
+            achternaam: 'Janssens',
+            'e-mail': 'jan.janssens@example.com',
+            mobiel: ' ',
+          }),
+          /Enkel een plusteken en cijfers zijn toegelaten/,
+          'whitespace is invalid',
+        );
+      });
+
       test('telefoon', async function (assert) {
         await assert.rejects(
           validate(vertegenwoordigerValidationSchema, {
@@ -261,6 +285,7 @@ module('Unit | Utility | verenigingsregister', function () {
           voornaam: 'Jan',
           achternaam: 'Janssens',
           'e-mail': '',
+          mobiel: '',
           telefoon: '',
           socialMedia: '',
         };


### PR DESCRIPTION
## ID

CLBV-1251

## Description

Add an extra optional field `Mobiel nummer` for representatives.

## Testing Instructions

1. proxy to dev, login as gemeente aartselaar, and open `http://localhost:4200/vereniging/147685cd-fc90-5b35-8d49-055a38c0342d/vertegenwoordigers`
2. Confirm there is a new field `Mobiel nummer` before the telefoonnummer, same behavior.