### PR TITLE
[CLBV-1270] Adjust the no-jurisdiction message to cover province and district logins

### DIFF
--- a/app/templates/association/representatives/index.gts
+++ b/app/templates/association/representatives/index.gts
@@ -325,9 +325,9 @@ const NoJurisdictionMessage = <template>
       Waarom zie ik geen gegevens van vertegenwoordigers van deze vereniging?
     </AuHeading>
     <p>
-      Je ziet alleen vertegenwoordigers van verenigingen die jouw gemeente als
-      primaire locatie hebben. Als er geen primaire locatie is aangeduid,
-      gebruiken we het maatschappelijke adres uit de KBO. Is dat niet
+      Je ziet alleen vertegenwoordigers van verenigingen waarvan de primaire
+      locatie binnen jouw werkingsgebied ligt. Als er geen primaire locatie is
+      aangeduid, gebruiken we het maatschappelijke adres uit de KBO. Is dat niet
       beschikbaar, dan nemen we het correspondentieadres als primair adres.
     </p>
   </AuContent>


### PR DESCRIPTION
With lblod/verenigingsregister-proxy-service#12, representatives are no longer scoped to the own gemeente/stad only, so the `NoJurisdictionMessage` copy now says "primaire locatie binnen jouw werkingsgebied" instead of "jouw gemeente als primaire locatie". Only occurrence of that wording in the codebase; the KBO-fallback sentences are unchanged.